### PR TITLE
Test cases are failing on Appveyor #157

### DIFF
--- a/src/main/java/seedu/address/model/task/ReadOnlyTask.java
+++ b/src/main/java/seedu/address/model/task/ReadOnlyTask.java
@@ -83,7 +83,8 @@ public interface ReadOnlyTask {
 
     default void buildNameString(final StringBuilder builder) {
         builder.append(getName());
-        builder.append("\n");
+        // TODO to remove all the line separators and rebuild toString(), create a getCLIOutput instead
+        builder.append(System.lineSeparator());
     }
 
     default void buildDeadlineString(final StringBuilder builder) {

--- a/src/test/java/guitests/TaskListGuiTest.java
+++ b/src/test/java/guitests/TaskListGuiTest.java
@@ -120,7 +120,21 @@ public abstract class TaskListGuiTest {
      * Asserts the message shown in the Result Display area is same as the given string.
      */
     protected void assertResultMessage(String expected) {
-        assertEquals(expected, resultDisplay.getText());
+//        System.out.println("Expected");
+//        System.out.println("Length: " + expected.getBytes(Charsets.UTF_8).length);
+//        System.out.println(Arrays.toString(expected.getBytes(Charsets.UTF_8)));
+//        System.out.println("Expected End");
+//        System.out.println("resultDisplay");
+//        System.out.println("Length: " + resultDisplay.getText().getBytes(Charsets.UTF_8).length);
+//        System.out.println(Arrays.toString(resultDisplay.getText().getBytes(Charsets.UTF_8)));
+//        System.out.println("resultDisplay End");
+//        System.out.println("Difference begin");
+//        System.out.println("Length: " + StringUtils.difference(expected, resultDisplay.getText()).length());
+//        System.out.println(StringUtils.difference(expected, resultDisplay.getText()));
+//        System.out.println("Distance: " + StringUtils.getLevenshteinDistance(expected, resultDisplay.getText()));
+//        System.out.println("Difference end");
+//        assertEquals(expected, resultDisplay.getText());
+        assertEquals(expected.replaceAll("\\s+", ""), resultDisplay.getText().replaceAll("\\s+", ""));
     }
 
     public void raise(BaseEvent e) {

--- a/src/test/java/guitests/TaskListGuiTest.java
+++ b/src/test/java/guitests/TaskListGuiTest.java
@@ -120,21 +120,10 @@ public abstract class TaskListGuiTest {
      * Asserts the message shown in the Result Display area is same as the given string.
      */
     protected void assertResultMessage(String expected) {
-//        System.out.println("Expected");
-//        System.out.println("Length: " + expected.getBytes(Charsets.UTF_8).length);
-//        System.out.println(Arrays.toString(expected.getBytes(Charsets.UTF_8)));
-//        System.out.println("Expected End");
-//        System.out.println("resultDisplay");
-//        System.out.println("Length: " + resultDisplay.getText().getBytes(Charsets.UTF_8).length);
-//        System.out.println(Arrays.toString(resultDisplay.getText().getBytes(Charsets.UTF_8)));
-//        System.out.println("resultDisplay End");
-//        System.out.println("Difference begin");
-//        System.out.println("Length: " + StringUtils.difference(expected, resultDisplay.getText()).length());
-//        System.out.println(StringUtils.difference(expected, resultDisplay.getText()));
-//        System.out.println("Distance: " + StringUtils.getLevenshteinDistance(expected, resultDisplay.getText()));
-//        System.out.println("Difference end");
-//        assertEquals(expected, resultDisplay.getText());
-        assertEquals(expected.replaceAll("\\s+", ""), resultDisplay.getText().replaceAll("\\s+", ""));
+        // TODO Strange regression where expected contains "\r\n" as line separator while
+        // resultDisplay.getText() only uses "\n" as line separator. Could it be that JavaFX
+        // TextArea automatically convert "\r\n" to "\n"?
+        assertEquals(expected.replaceAll("\\r\\n", "\n"), resultDisplay.getText().replaceAll("\\r\\n", "\n"));
     }
 
     public void raise(BaseEvent e) {


### PR DESCRIPTION
`TaskListGuiTest#assertResultMessage`

Strange regression where `expected` contains "\r\n" as line separator while
resultDisplay.getText() only uses "\n" as line separator. Could it be that JavaFX
textfields automatically convert "\r\n" to "\n"?

**Basic Outline of solution**
As a temporary fix, replace all line separators with Unix-based line separators (i.e. "\n"). 

Closes #157 